### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - '0.12'
   - '4'
 before_script:
-  - npm install -g grunt-cli
   - ./create_config.sh
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphere-node-sdk",
   "description": "Officially supported Node.js SDK library for working with the SPHERE.IO HTTP API, with OAuth2 support.",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "homepage": "https://github.com/sphereio/sphere-node-sdk",
   "author": {
     "name": "Nicola Molinari",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "commit": "git-cz",
     "build": "grunt build",
+    "watch": "grunt watch",
     "test": "grunt coverage"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphere-node-sdk",
   "description": "Officially supported Node.js SDK library for working with the SPHERE.IO HTTP API, with OAuth2 support.",
-  "version": "1.16.2",
+  "version": "1.17.0",
   "homepage": "https://github.com/sphereio/sphere-node-sdk",
   "author": {
     "name": "Nicola Molinari",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphere-node-sdk",
   "description": "Officially supported Node.js SDK library for working with the SPHERE.IO HTTP API, with OAuth2 support.",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "homepage": "https://github.com/sphereio/sphere-node-sdk",
   "author": {
     "name": "Nicola Molinari",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "istanbul": "0.3.x",
     "jasmine-node": "1.14.5",
     "sphere-coffeelint": "git://github.com/sphereio/sphere-coffeelint.git#master",
+    "sphere-node-utils": "^0.8.4",
     "underscore": "1.8.x",
     "underscore-mixins": "0.1.x",
     "validate-commit-msg": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphere-node-sdk",
   "description": "Officially supported Node.js SDK library for working with the SPHERE.IO HTTP API, with OAuth2 support.",
-  "version": "1.17.0",
+  "version": "1.17.2",
   "homepage": "https://github.com/sphereio/sphere-node-sdk",
   "author": {
     "name": "Nicola Molinari",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "debug": "2.1.x",
     "jsondiffpatch": "0.1.31",
-    "request": "2.54.x"
+    "request": "2.54.x",
+    "sphere-node-utils": "^0.8.4"
   },
   "peerDependencies": {
     "bluebird": ">=2.3.0",
@@ -57,7 +58,6 @@
     "istanbul": "0.3.x",
     "jasmine-node": "1.14.5",
     "sphere-coffeelint": "git://github.com/sphereio/sphere-coffeelint.git#master",
-    "sphere-node-utils": "^0.8.4",
     "underscore": "1.8.x",
     "underscore-mixins": "0.1.x",
     "validate-commit-msg": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "debug": "2.1.x",
     "jsondiffpatch": "0.1.31",
-    "request": "2.54.x"
+    "request": "2.74.0"
   },
   "peerDependencies": {
     "bluebird": ">=2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphere-node-sdk",
   "description": "Officially supported Node.js SDK library for working with the SPHERE.IO HTTP API, with OAuth2 support.",
-  "version": "1.15.5",
+  "version": "1.16.0",
   "homepage": "https://github.com/sphereio/sphere-node-sdk",
   "author": {
     "name": "Nicola Molinari",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ghooks": "1.0.3",
     "grunt": "0.4.5",
     "grunt-bump": "0.0.13",
+    "grunt-cli": "^1.2.0",
     "grunt-coffeelint": "0.0.13",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-coffee": "0.13.x",

--- a/src/coffee/client.coffee
+++ b/src/coffee/client.coffee
@@ -1,5 +1,6 @@
 _                        = require 'underscore'
 Rest                     = require './connect/rest'
+TaskQueue                = require './task-queue'
 RepeaterTaskQueue        = require '../lib/repeater-task-queue'
 CartDiscountService      = require './services/cart-discounts'
 CartService              = require './services/carts'
@@ -75,6 +76,11 @@ ALL_SERVICES = [
 # To optimize processing lots of requests all together, e.g.: avoiding connection timeouts, we introduced {TaskQueue}.
 # Every request is internally pushed in a queue which automatically starts resolving promises (requests)
 # and will process concurrently some of them based on the `maxParallel` parameter. You can set this parameter by calling {::setMaxParallel}.
+#
+# ### RepeaterTaskQueue
+# To repeat request on case of some errors. It's possible to use custom repeater by passing it to constructor.
+# Also it's possible to turn off by passing `enableRepeater = false` flag.
+# There is a default repeater if constructor parameter is empty.
 #
 # ```coffeescript
 # client = new SphereClient # a TaskQueue is internally initialized at this point with maxParallel of 20
@@ -221,7 +227,10 @@ class SphereClient
   # options - An {Object} to configure the client
   constructor: (options = {}) ->
     # Private: instance of a {TaskQueue}
-    @_task = options.task or new RepeaterTaskQueue {}, { attempts: 50, timeout: 200, timeoutType: 'v' }
+    if options.enableRepeater? and !options.enableRepeater
+      @_task = new TaskQueue
+    else
+      @_task = options.task or new RepeaterTaskQueue {}, { attempts: 50, timeout: 200, timeoutType: 'v' }
 
     # Private: instance of a {Rest}
     @_rest = options.rest or new Rest _.defaults options, {user_agent: 'sphere-node-sdk'}

--- a/src/coffee/client.coffee
+++ b/src/coffee/client.coffee
@@ -1,6 +1,6 @@
-_ = require 'underscore'
-Rest = require './connect/rest'
-TaskQueue = require './task-queue'
+_                        = require 'underscore'
+Rest                     = require './connect/rest'
+RepeaterTaskQueue        = require '../lib/repeater-task-queue'
 CartDiscountService      = require './services/cart-discounts'
 CartService              = require './services/carts'
 CategoryService          = require './services/categories'
@@ -220,9 +220,8 @@ class SphereClient
   #
   # options - An {Object} to configure the client
   constructor: (options = {}) ->
-
     # Private: instance of a {TaskQueue}
-    @_task = options.task or new TaskQueue
+    @_task = options.task or new RepeaterTaskQueue {}, { attempts: 50, timeout: 200, timeoutType: 'v' }
 
     # Private: instance of a {Rest}
     @_rest = options.rest or new Rest _.defaults options, {user_agent: 'sphere-node-sdk'}

--- a/src/coffee/client.coffee
+++ b/src/coffee/client.coffee
@@ -230,7 +230,7 @@ class SphereClient
     if options.enableRepeater? and !options.enableRepeater
       @_task = new TaskQueue
     else
-      @_task = options.task or new RepeaterTaskQueue {}, { attempts: 50, timeout: 200, timeoutType: 'v' }
+      @_task = options.task or new RepeaterTaskQueue {}, {}
 
     # Private: instance of a {Rest}
     @_rest = options.rest or new Rest _.defaults options, {user_agent: 'sphere-node-sdk'}

--- a/src/coffee/connect/oauth2.coffee
+++ b/src/coffee/connect/oauth2.coffee
@@ -49,7 +49,7 @@ class OAuth2
       host: host
       protocol: protocol
       accessTokenUrl: opts.accessTokenUrl or '/oauth/token'
-      timeout: opts.timeout or 20000
+      timeout: opts.timeout or 60000
       rejectUnauthorized: rejectUnauthorized
       userAgent: userAgent
 

--- a/src/coffee/repeater-task-queue.coffee
+++ b/src/coffee/repeater-task-queue.coffee
@@ -1,0 +1,73 @@
+{ Repeater } = require 'sphere-node-utils'
+Promise = require 'bluebird'
+util = require 'util'
+TaskQueue = require './task-queue'
+
+# Response messages which will be handled by `RepeaterTaskQueue`
+retryKeywords = [
+  'ETIMEDOUT'
+  'socket hang up'
+  'write EPROTO'
+  'Retry later'
+  'I am the LoadBalancer of'
+  'Gateway Timeout'
+  'Bad Gateway'
+  'EAI_AGAIN'
+  'ESOCKETTIMEDOUT'
+  'Oops. This shouldn\'t happen'
+  'InternalServerError: Undefined'
+  'Temporary overloading'
+  'read ECONNRESET'
+  'getaddrinfo ENOTFOUND'
+  'Cannot commit on stream id'
+]
+
+# Public: A `RepeaterTaskQueue` adds request repeater on particular response errors
+#
+# `RepeaterTaskQueue` receives two objects as parameter.
+# First object overriding `maxParallel` value of `TaskQueue`
+# Second object contains information about the count of attempts, timeout and timeout type.
+# There are 2 types of `timeoutType`:
+# - `c`: constant delay
+# - `v`: variable delay (grows with attempts count with a random component)
+#
+#
+#  Examples
+#
+#   task = new RepeaterTaskQueue { maxParallel: 30 }, { attempts: 50, timeout: 200, timeoutType: 'v' }
+class RepeaterTaskQueue extends TaskQueue
+
+
+  constructor: (options, repeaterOptions) ->
+    super options
+    @repeaterOptions = repeaterOptions
+
+
+  _startTask: (task) =>
+    @_activeCount += 1
+    repeater = new Repeater(@repeaterOptions)
+    toRepeat = repeater.execute task.fn, (err) =>
+      if @_shouldRetry(err)
+        return Promise.resolve()
+      else
+        Promise.reject err
+    toRepeat.then (res) ->
+      task.resolve res
+      return
+    .catch (err) ->
+      task.reject err
+      return
+    .finally =>
+      @_activeCount -= 1
+      @_maybeExecute()
+    .done()
+
+
+  _shouldRetry: (error) ->
+    if error and (error.code and util.inspect(error.code).startsWith('5') or error.statusCode and util.inspect(error.statusCode).startsWith('5'))
+      return true
+    retryKeywords.find (str) ->
+      util.inspect(error, depth: null).toUpperCase().indexOf(str.toUpperCase()) > -1
+      return
+
+module.exports = RepeaterTaskQueue

--- a/src/coffee/repeater-task-queue.coffee
+++ b/src/coffee/repeater-task-queue.coffee
@@ -2,6 +2,7 @@
 Promise = require 'bluebird'
 util = require 'util'
 TaskQueue = require './task-queue'
+_ = require 'underscore'
 
 # Response messages which will be handled by `RepeaterTaskQueue`
 retryKeywords = [
@@ -26,20 +27,25 @@ retryKeywords = [
 #
 # `RepeaterTaskQueue` receives two objects as parameter.
 # First object overriding `maxParallel` value of `TaskQueue`
-# Second object contains information about the count of attempts, timeout and timeout type.
+# Second object contains information about the count of attempts, timeout, timeout type and retry keywords.
 # There are 2 types of `timeoutType`:
 # - `c`: constant delay
 # - `v`: variable delay (grows with attempts count with a random component)
-#
+# It's possible to customize default list of handled error messages. To do this just pass new array to `retryKeywords`
 #
 #  Examples
 #
-#   task = new RepeaterTaskQueue { maxParallel: 30 }, { attempts: 50, timeout: 200, timeoutType: 'v' }
+#   task = new RepeaterTaskQueue { maxParallel: 30 }, { attempts: 50, timeout: 200, timeoutType: 'v', retryKeywords: ['test1', 'test2'] }
 class RepeaterTaskQueue extends TaskQueue
 
 
   constructor: (options, repeaterOptions) ->
     super options
+    repeaterOptions = _.defaults repeaterOptions,
+      attempts: 50
+      timeout: 200
+      timeoutType: 'v'
+      retryKeywords: retryKeywords
     @repeaterOptions = repeaterOptions
 
 
@@ -66,7 +72,7 @@ class RepeaterTaskQueue extends TaskQueue
   _shouldRetry: (error) ->
     if error and (error.code and util.inspect(error.code).startsWith('5') or error.statusCode and util.inspect(error.statusCode).startsWith('5'))
       return true
-    retryKeywords.find (str) ->
+    @repeaterOptions.retryKeywords.find (str) ->
       util.inspect(error, depth: null).toUpperCase().indexOf(str.toUpperCase()) > -1
       return
 

--- a/src/coffee/repeater-task-queue.coffee
+++ b/src/coffee/repeater-task-queue.coffee
@@ -1,6 +1,5 @@
 { Repeater } = require 'sphere-node-utils'
 Promise = require 'bluebird'
-util = require 'util'
 TaskQueue = require './task-queue'
 _ = require 'underscore'
 
@@ -70,10 +69,9 @@ class RepeaterTaskQueue extends TaskQueue
 
 
   _shouldRetry: (error) ->
-    if error and (error.code and util.inspect(error.code).startsWith('5') or error.statusCode and util.inspect(error.statusCode).startsWith('5'))
-      return true
-    @repeaterOptions.retryKeywords.find (str) ->
-      util.inspect(error, depth: null).toUpperCase().indexOf(str.toUpperCase()) > -1
-      return
+    return error?.code?.toString().startsWith('5') or
+        error?.statusCode?.toString().startsWith('5') or
+        @repeaterOptions.retryKeywords.some (keyword) ->
+          JSON.stringify(error).toUpperCase().includes(keyword.toUpperCase())
 
 module.exports = RepeaterTaskQueue

--- a/src/coffee/sync/inventory-sync.coffee
+++ b/src/coffee/sync/inventory-sync.coffee
@@ -7,6 +7,7 @@ InventoryUtils = require './utils/inventory'
 # Action groups for products are:
 # - `quantity`
 # - `expectedDelivery`
+# - `custom`
 #
 # Examples
 #
@@ -20,7 +21,7 @@ InventoryUtils = require './utils/inventory'
 #     # do nothing
 class InventorySync extends BaseSync
 
-  @actionGroups = ['quantity', 'expectedDelivery']
+  @actionGroups = ['quantity', 'expectedDelivery', 'custom']
 
   # Public: Construct a `InventorySync` object.
   constructor: ->
@@ -31,6 +32,7 @@ class InventorySync extends BaseSync
     allActions = []
     allActions.push @_mapActionOrNot 'quantity', => @_utils.actionsMapQuantity(diff, old_obj)
     allActions.push @_mapActionOrNot 'expectedDelivery', => @_utils.actionsMapExpectedDelivery(diff, old_obj)
+    allActions.push @_mapActionOrNot 'custom', => @_utils.actionsMapCustom(diff, old_obj, new_obj)
     _.flatten allActions
 
 module.exports = InventorySync

--- a/src/coffee/sync/inventory-sync.coffee
+++ b/src/coffee/sync/inventory-sync.coffee
@@ -32,7 +32,7 @@ class InventorySync extends BaseSync
     allActions = []
     allActions.push @_mapActionOrNot 'quantity', => @_utils.actionsMapQuantity(diff, old_obj)
     allActions.push @_mapActionOrNot 'expectedDelivery', => @_utils.actionsMapExpectedDelivery(diff, old_obj)
-    allActions.push @_mapActionOrNot 'custom', => @_utils.actionsMapCustom(diff, old_obj)
+    allActions.push @_mapActionOrNot 'custom', => @_utils.actionsMapCustom(diff, old_obj, new_obj)
     _.flatten allActions
 
 module.exports = InventorySync

--- a/src/coffee/sync/inventory-sync.coffee
+++ b/src/coffee/sync/inventory-sync.coffee
@@ -32,7 +32,7 @@ class InventorySync extends BaseSync
     allActions = []
     allActions.push @_mapActionOrNot 'quantity', => @_utils.actionsMapQuantity(diff, old_obj)
     allActions.push @_mapActionOrNot 'expectedDelivery', => @_utils.actionsMapExpectedDelivery(diff, old_obj)
-    allActions.push @_mapActionOrNot 'custom', => @_utils.actionsMapCustom(diff, old_obj, new_obj)
+    allActions.push @_mapActionOrNot 'custom', => @_utils.actionsMapCustom(diff, old_obj)
     _.flatten allActions
 
 module.exports = InventorySync

--- a/src/coffee/sync/utils/inventory.coffee
+++ b/src/coffee/sync/utils/inventory.coffee
@@ -52,15 +52,18 @@ class InventoryUtils extends BaseUtils
   #
   # diff - {Object} The result of diff from `jsondiffpatch`
   # old_obj - {Object} The existing inventory
-  # new_obj - {Object} The new inventory
   #
   # Returns {Array} The list of actions, or empty if there are none
-  actionsMapCustom: (diff, old_obj, new_obj) =>
+  actionsMapCustom: (diff, old_obj) =>
     actions = []
     if !diff.custom
       return actions
 
     # if custom is new in itself it's placed in an array we need to unwrap
+    if Array.isArray(diff.custom)
+      diff.custom = diff.custom[0]
+
+    # if custom's type is new it's placed in an array we need to unwrap
     if diff.custom.type
       diff.custom.type = diff.custom.type[0] || diff.custom.type
 
@@ -69,14 +72,14 @@ class InventoryUtils extends BaseUtils
         action: 'setCustomType'
         type:
           typeId: 'type',
-          id: if Array.isArray(diff.custom.type.id) then @getDeltaValue(diff.custom.type.id) else new_obj.custom.type.id
-        fields: if Array.isArray(diff.custom.fields) then @getDeltaValue(diff.custom.fields) else new_obj.custom.fields
+          id: if Array.isArray(diff.custom.type.id) then @getDeltaValue(diff.custom.type.id) else diff.custom.type.id
+        fields: if Array.isArray(diff.custom.fields) then @getDeltaValue(diff.custom.fields) else diff.custom.fields
     else if diff.custom.fields
       customFieldsActions = Object.keys(diff.custom.fields).map((name) =>
         {
           action: 'setCustomField'
           name: name
-          value: if Array.isArray(diff.custom.fields[name]) then @getDeltaValue(diff.custom.fields[name]) else new_obj.custom.fields[name]
+          value: if Array.isArray(diff.custom.fields[name]) then @getDeltaValue(diff.custom.fields[name]) else diff.custom.fields[name]
         }
       )
       actions = actions.concat(customFieldsActions)

--- a/src/coffee/sync/utils/inventory.coffee
+++ b/src/coffee/sync/utils/inventory.coffee
@@ -54,7 +54,7 @@ class InventoryUtils extends BaseUtils
   # old_obj - {Object} The existing inventory
   #
   # Returns {Array} The list of actions, or empty if there are none
-  actionsMapCustom: (diff, old_obj) =>
+  actionsMapCustom: (diff, old_obj, new_obj) =>
     actions = []
     if !diff.custom
       return actions
@@ -79,7 +79,7 @@ class InventoryUtils extends BaseUtils
         {
           action: 'setCustomField'
           name: name
-          value: if Array.isArray(diff.custom.fields[name]) then @getDeltaValue(diff.custom.fields[name]) else diff.custom.fields[name]
+          value: if Array.isArray(diff.custom.fields[name]) then @getDeltaValue(diff.custom.fields[name]) else new_obj.custom.fields[name]
         }
       )
       actions = actions.concat(customFieldsActions)

--- a/src/coffee/sync/utils/inventory.coffee
+++ b/src/coffee/sync/utils/inventory.coffee
@@ -48,4 +48,38 @@ class InventoryUtils extends BaseUtils
         actions.push a
     actions
 
+  # Private: map inventory custom type and fields
+  #
+  # diff - {Object} The result of diff from `jsondiffpatch`
+  # old_obj - {Object} The existing inventory
+  # new_obj - {Object} The new inventory
+  #
+  # Returns {Array} The list of actions, or empty if there are none
+  actionsMapCustom: (diff, old_obj, new_obj) =>
+    actions = []
+    if !diff.custom
+      return actions
+
+    # if custom is new in itself it's placed in an array we need to unwrap
+    if diff.custom.type
+      diff.custom.type = diff.custom.type[0] || diff.custom.type
+
+    if diff.custom.type && diff.custom.type.id
+      actions.push
+        action: 'setCustomType'
+        type:
+          typeId: 'type',
+          id: if Array.isArray(diff.custom.type.id) then @getDeltaValue(diff.custom.type.id) else new_obj.custom.type.id
+        fields: if Array.isArray(diff.custom.fields) then @getDeltaValue(diff.custom.fields) else new_obj.custom.fields
+    else if diff.custom.fields
+      customFieldsActions = Object.keys(diff.custom.fields).map((name) =>
+        {
+          action: 'setCustomField'
+          name: name
+          value: if Array.isArray(diff.custom.fields[name]) then @getDeltaValue(diff.custom.fields[name]) else new_obj.custom.fields[name]
+        }
+      )
+      actions = actions.concat(customFieldsActions)
+    actions
+
 module.exports = InventoryUtils

--- a/src/spec/client/client.spec.coffee
+++ b/src/spec/client/client.spec.coffee
@@ -77,7 +77,7 @@ describe 'SphereClient', ->
     expect(=> @client.setMaxParallel(0)).toThrow new Error 'MaxParallel must be a number between 1 and 100'
     expect(=> @client.setMaxParallel(101)).toThrow new Error 'MaxParallel must be a number between 1 and 100'
 
-  it 'should not repeat request on error',(done) ->
+  it 'should not repeat request on error if repeater is disabled',(done) ->
     client =  new SphereClient {config: Config, enableRepeater: false}
     callsMap = {
       0: { statusCode: 500, message: 'ETIMEDOUT' }

--- a/src/spec/client/client.spec.coffee
+++ b/src/spec/client/client.spec.coffee
@@ -77,6 +77,26 @@ describe 'SphereClient', ->
     expect(=> @client.setMaxParallel(0)).toThrow new Error 'MaxParallel must be a number between 1 and 100'
     expect(=> @client.setMaxParallel(101)).toThrow new Error 'MaxParallel must be a number between 1 and 100'
 
+  it 'should not repeat request on error',(done) ->
+    client =  new SphereClient {config: Config, enableRepeater: false}
+    callsMap = {
+      0: { statusCode: 500, message: 'ETIMEDOUT' }
+      1: { statusCode: 500, message: 'ETIMEDOUT' }
+      2: { statusCode: 200, message: 'success' }
+    }
+    callCount = 0
+    spyOn(client._rest, 'GET').andCallFake (resource, callback) ->
+      currentCall = callsMap[callCount]
+      callCount++
+      statusCode = currentCall.statusCode
+      message = currentCall.message
+      callback(null, { statusCode }, { message })
+
+    client.products.fetch()
+    .catch (err) ->
+      expect(client._rest.GET.calls.length).toEqual 1
+      expect(err.body.message).toEqual 'ETIMEDOUT'
+      done()
 
   _.each [
     {name: 'cartDiscounts', className: 'CartDiscountService', blacklist: []}

--- a/src/spec/connect/oauth2.spec.coffee
+++ b/src/spec/connect/oauth2.spec.coffee
@@ -10,7 +10,7 @@ describe 'OAuth2', ->
     expect(oa._options.host).toBe 'auth.sphere.io'
     expect(oa._options.protocol).toBe 'https'
     expect(oa._options.accessTokenUrl).toBe '/oauth/token'
-    expect(oa._options.timeout).toBe 20000
+    expect(oa._options.timeout).toBe 60000
     expect(oa._options.rejectUnauthorized).toBe true
 
   it 'should throw error if no credentials are given', ->

--- a/src/spec/integration/inventories-sync.spec.coffee
+++ b/src/spec/integration/inventories-sync.spec.coffee
@@ -101,3 +101,68 @@ describe 'Integration Inventories Sync', ->
       expect(result.body.expectedDelivery).not.toBeDefined()
       done()
     .catch (error) -> done(_.prettify(error))
+
+  describe 'custom type and field handling', (done) ->
+    customType = undefined
+    inventoryEntry = undefined
+
+    typesCleanup = (client) ->
+      client.types.all().fetch()
+        .then (result) ->
+          Promise.all _.map result.body.results, (e) ->
+            client.types.byId(e.id).delete(e.version)
+        .then (results) ->
+          debug('Cleaned up all custom types.')
+          Promise.resolve()
+
+    beforeEach (done) ->
+      @client = new SphereClient config: Config
+      customTypePayload = {
+        key: 'my-type',
+        name: { 'en': 'customized fields' },
+        description: { 'en': 'customized fields definition' },
+        resourceTypeIds: ['inventory-entry'],
+        fieldDefinitions: [
+          {
+            name: 'nac',
+            type: { 'name': 'String' },
+            required: true,
+            label: { 'en': 'size' },
+            inputHint: 'SingleLine'
+          }
+        ]
+      }
+      typesCleanup(@client).then =>
+        @client.types.create(customTypePayload).then (result) ->
+          customType = result.body
+          done()
+
+    it 'should update custom type and fields', (done) ->
+      ie =
+        sku: 'x6'
+        quantityOnStock: 0
+        custom: {
+          type: {
+            key: 'my-type'
+          },
+          fields: {
+            nac: 'ho'
+          }
+        }
+      ieChanged =
+        sku: 'x6'
+        quantityOnStock: 7
+
+      @client.inventoryEntries.create(ie)
+        .then (result) =>
+          expect(result.statusCode).toBe 201
+          syncedActions = @sync.buildActions(ieChanged, result.body)
+          debug 'About to update inventory with synced actions (quantity)'
+          @client.inventoryEntries.byId(syncedActions.getUpdateId()).update(syncedActions.getUpdatePayload())
+        .then (result) ->
+          inventoryEntry = result.body
+          expect(result.statusCode).toBe 200
+          expect(result.body.custom.type.id).toBe customType.id
+          expect(result.body.custom.fields).toEqual {nac: 'ho'}
+          done()
+        .catch (error) -> done(_.prettify(error))

--- a/src/spec/integration/inventories-sync.spec.coffee
+++ b/src/spec/integration/inventories-sync.spec.coffee
@@ -101,6 +101,7 @@ describe 'Integration Inventories Sync', ->
       expect(result.body.expectedDelivery).not.toBeDefined()
       done()
     .catch (error) -> done(_.prettify(error))
+  , 60000
 
   describe 'custom type and field handling', (done) ->
     customType = undefined

--- a/src/spec/integration/orders-sync.spec.coffee
+++ b/src/spec/integration/orders-sync.spec.coffee
@@ -63,6 +63,8 @@ describe 'Integration Orders Sync', ->
       expect(orderUpdated.shipmentState).toBe orderNew.shipmentState
       done()
     .catch (error) -> done(_.prettify(error))
+  , 60000
+
 
   it 'should sync returnInfo', (done) ->
     orderNew = _.deepClone @order
@@ -87,6 +89,7 @@ describe 'Integration Orders Sync', ->
       expect(orderUpdated.returnInfo[0].id).toBe orderNew.returnInfo[0].id
       done()
     .catch (error) -> done(_.prettify(error))
+  , 60000
 
   it 'should sync returnInfo (status)', (done) ->
     orderNew = _.deepClone @order
@@ -125,6 +128,7 @@ describe 'Integration Orders Sync', ->
       expect(orderUpdated2.returnInfo[0].items[0].paymentState).toEqual @orderNew2.returnInfo[0].items[0].paymentState
       done()
     .catch (error) -> done(_.prettify(error))
+  , 60000
 
   it 'should sync delivery items', (done) ->
 
@@ -148,6 +152,7 @@ describe 'Integration Orders Sync', ->
       expect(orderUpdated.shippingInfo.deliveries.length).toBe 1
       done()
     .catch (error) -> done(_.prettify(error))
+  , 60000
 
   it 'should sync parcel items of a delivery', (done) ->
     orderNew = _.deepClone @order
@@ -211,7 +216,7 @@ describe 'Integration Orders Sync', ->
       expect(parcels.length).toBe 2
       done()
     .catch (error) -> done(_.prettify(error))
-
+  , 60000
 ###
 helper methods
 ###

--- a/src/spec/integration/products-sync.spec.coffee
+++ b/src/spec/integration/products-sync.spec.coffee
@@ -248,7 +248,7 @@ describe 'Integration Products Sync', ->
       expect(updated.variants[1].prices[0].country).toBe 'FR'
       done()
     .catch (error) -> done(_.prettify(error))
-  , 10000 # 10sec
+  , 30000 # 30sec
 
   describe 'State update actions', ->
 
@@ -696,6 +696,6 @@ describe 'Integration Products Sync', ->
           expect(updated.masterVariant.prices[0].custom.fields.kiloPrice.centAmount).toBe 4948
           done()
         .catch (error) -> done(_.prettify(error))
-
+    , 60000
 
 

--- a/src/spec/integration/products-sync.spec.coffee
+++ b/src/spec/integration/products-sync.spec.coffee
@@ -374,3 +374,328 @@ describe 'Integration Products Sync', ->
       .catch (error) ->
         done(_.prettify(error))
     , 10000 # 10sec
+  
+  describe 'price custom type and field handling', (done) ->
+    customTypes = []
+
+    typesCleanup = (client) ->
+      customTypes = []
+      client.types.all().fetch()
+        .then (result) ->
+          Promise.all _.map result.body.results, (e) ->
+            client.types.byId(e.id).delete(e.version)
+        .then (results) ->
+          debug('Cleaned up all custom types.')
+          Promise.resolve()
+        .catch (error) ->
+          Promise.resolve(error)
+
+    beforeEach (done) ->
+      @client = new SphereClient config: Config
+      customTypePayloads = [
+        {
+          "key": "price-withKilosPrice",
+          "name": {
+            "en": "additional custom field kiloPrice"
+          },
+          "resourceTypeIds": [
+            "product-price"
+          ],
+          "fieldDefinitions": [
+            {
+              "type": {
+                "name": "Money"
+              },
+              "name": "kiloPrice",
+              "label": {
+                "en": "kilo price"
+              },
+              "required": false,
+              "inputHint": "SingleLine"
+            }
+          ]
+        },
+        {
+          "key": "price-withKilosPrice-two",
+          "name": {
+            "en": "additional custom field kiloPrice"
+          },
+          "resourceTypeIds": [
+            "product-price"
+          ],
+          "fieldDefinitions": [
+            {
+              "type": {
+                "name": "Money"
+              },
+              "name": "kiloPrice",
+              "label": {
+                "en": "kilo price"
+              },
+              "required": false,
+              "inputHint": "SingleLine"
+            }
+          ]
+        }
+      ]
+
+      typesCleanup(@client).then =>
+        @client.types.create(customTypePayloads[0])
+          .then (result) =>
+            customTypes.push(result.body)
+            @client.types.create(customTypePayloads[1])
+          .then (result) ->
+            customTypes.push(result.body)
+            done()
+          .catch (error) ->
+            debug error
+            done()
+
+    it 'should update price custom type id', (done) ->
+      pName = uniqueId('Foo')
+      pSlug = uniqueId('foo')
+      OLD_PROD =
+        productType:
+          id: @productType.id
+          typeId: 'product-type'
+        name: {de: pName}
+        slug: {de: pSlug}
+        description: {de: 'A foo product'}
+        masterVariant:
+          id: 1
+          sku: 'v2'
+          prices: [
+            {
+              value: {
+                centAmount: 1000,
+                currencyCode: 'EUR'
+              },
+              custom: {
+                type: {
+                  typeId: 'type',
+                  id: customTypes[0].id,
+                }
+                fields: {
+                  kiloPrice: {
+                    currencyCode: 'EUR',
+                    centAmount: 2000
+                  }
+                }
+              }
+            }
+          ]
+
+      NEW_PROD =
+        productType:
+          id: @productType.id
+          typeId: 'product-type'
+        name: {de: pName}
+        slug: {de: pSlug}
+        description: {de: 'A foo product'}
+        masterVariant:
+          id: 1
+          sku: 'v2'
+          prices: [
+            {
+              value: {
+                centAmount: 1000,
+                currencyCode: 'EUR'
+              },
+              custom: {
+                type: {
+                  typeId: 'type',
+                  id: customTypes[1].id,
+                }
+                fields: {
+                  kiloPrice: {
+                    currencyCode: 'EUR',
+                    centAmount: 2000
+                  }
+                }
+              }
+            }
+          ]
+
+      debug 'Create initial product to be synced'
+      @client.products.create(OLD_PROD)
+        .then (result) =>
+          debug 'Fetch projection of created product'
+          @client.productProjections.byId(result.body.id).staged(true).fetch()
+        .then (result) =>
+          syncedActions = @sync.buildActions(NEW_PROD, result.body)
+          expect(syncedActions.shouldUpdate()).toBe true
+          updatePayload = syncedActions.getUpdatePayload()
+          debug 'About to update product with synced actions'
+          @client.products.byId(syncedActions.getUpdateId()).update(updatePayload)
+        .then (result) =>
+          debug 'Fetch projection of updated product'
+          @client.productProjections.byId(result.body.id).staged(true).fetch()
+        .then (result) ->
+          updated = result.body
+          expect(updated.masterVariant.prices[0].custom.type.id).toBe customTypes[1].id
+          done()
+        .catch (error) -> done(_.prettify(error))
+
+    it 'should update custom fields', (done) ->
+      pName = uniqueId('Foo')
+      pSlug = uniqueId('foo')
+      OLD_PROD =
+        productType:
+          id: @productType.id
+          typeId: 'product-type'
+        name: {de: pName}
+        slug: {de: pSlug}
+        description: {de: 'A foo product'}
+        masterVariant:
+          id: 1
+          sku: 'v2'
+          prices: [
+            {
+              value: {
+                centAmount: 1000,
+                currencyCode: 'EUR'
+              },
+              custom: {
+                type: {
+                  typeId: 'type',
+                  id: customTypes[0].id,
+                }
+                fields: {
+                  kiloPrice: {
+                    currencyCode: 'EUR',
+                    centAmount: 2000
+                  }
+                }
+              }
+            }
+          ]
+
+      NEW_PROD =
+        productType:
+          id: @productType.id
+          typeId: 'product-type'
+        name: {de: pName}
+        slug: {de: pSlug}
+        description: {de: 'A foo product'}
+        masterVariant:
+          id: 1
+          sku: 'v2'
+          prices: [
+            {
+              value: {
+                centAmount: 1000,
+                currencyCode: 'EUR'
+              },
+              custom: {
+                type: {
+                  typeId: 'type',
+                  id: customTypes[0].id,
+                }
+                fields: {
+                  kiloPrice: {
+                    currencyCode: 'JPY',
+                    centAmount: 9000
+                  }
+                }
+              }
+            }
+          ]
+
+      debug 'Create initial product to be synced'
+      @client.products.create(OLD_PROD)
+        .then (result) =>
+          debug 'Fetch projection of created product'
+          @client.productProjections.byId(result.body.id).staged(true).fetch()
+        .then (result) =>
+          syncedActions = @sync.buildActions(NEW_PROD, result.body)
+          expect(syncedActions.shouldUpdate()).toBe true
+          updatePayload = syncedActions.getUpdatePayload()
+          debug 'About to update product with synced actions'
+          @client.products.byId(syncedActions.getUpdateId()).update(updatePayload)
+        .then (result) =>
+          debug 'Fetch projection of updated product'
+          @client.productProjections.byId(result.body.id).staged(true).fetch()
+        .then (result) ->
+          updated = result.body
+          expect(updated.masterVariant.prices[0].custom.fields.kiloPrice.currencyCode).toBe 'JPY'
+          expect(updated.masterVariant.prices[0].custom.fields.kiloPrice.centAmount).toBe 9000
+          done()
+        .catch (error) -> done(_.prettify(error))
+
+    it 'should add price custom type and fields', (done) ->
+      pName = uniqueId('Foo')
+      pSlug = uniqueId('foo')
+      OLD_PROD =
+        productType:
+          id: @productType.id
+          typeId: 'product-type'
+        name: {de: pName}
+        slug: {de: pSlug}
+        description: {de: 'A foo product'}
+        masterVariant:
+          id: 1
+          sku: 'v2'
+          prices: [
+            {
+              value: {
+                centAmount: 1000,
+                currencyCode: 'EUR'
+              }
+            }
+          ]
+
+      NEW_PROD =
+        productType:
+          id: @productType.id
+          typeId: 'product-type'
+        name: {de: pName}
+        slug: {de: pSlug}
+        description: {de: 'A foo product'}
+        masterVariant:
+          id: 1
+          sku: 'v2'
+          prices: [
+            {
+              value: {
+                centAmount: 1000,
+                currencyCode: 'EUR'
+              },
+              custom: {
+                type: {
+                  typeId: 'type',
+                  id: customTypes[0].id,
+                }
+                fields: {
+                  kiloPrice: {
+                    currencyCode: 'EUR',
+                    centAmount: 4948
+                  }
+                }
+              }
+            }
+          ]
+
+      debug 'Create initial product to be synced'
+      @client.products.create(OLD_PROD)
+        .then (result) =>
+          debug 'Fetch projection of created product'
+          @client.productProjections.byId(result.body.id).staged(true).fetch()
+        .then (result) =>
+          syncedActions = @sync.buildActions(NEW_PROD, result.body)
+          expect(syncedActions.shouldUpdate()).toBe true
+          updatePayload = syncedActions.getUpdatePayload()
+          debug 'About to update product with synced actions'
+          @client.products.byId(syncedActions.getUpdateId()).update(updatePayload)
+        .then (result) =>
+          debug 'Fetch projection of updated product'
+          @client.productProjections.byId(result.body.id).staged(true).fetch()
+        .then (result) ->
+          updated = result.body
+          expect(updated.masterVariant.prices[0].custom.type.id).toBe customTypes[0].id
+          expect(updated.masterVariant.prices[0].custom.fields.kiloPrice.currencyCode).toBe 'EUR'
+          expect(updated.masterVariant.prices[0].custom.fields.kiloPrice.centAmount).toBe 4948
+          done()
+        .catch (error) -> done(_.prettify(error))
+
+
+

--- a/src/spec/integration/products.spec.coffee
+++ b/src/spec/integration/products.spec.coffee
@@ -153,7 +153,7 @@ describe 'Integration Products', ->
       expect(result.body.productType.hasOwnProperty('obj')).toBe(true)
       done()
     .catch (error) -> done(_.prettify(error))
-  , 30000 # 30sec
+  , 60000 # 60sec
 
   # it 'should search for suggestions', (done) ->
   #   debug 'Creating products with search keywords'

--- a/src/spec/repeater-task-queue.spec.coffee
+++ b/src/spec/repeater-task-queue.spec.coffee
@@ -1,0 +1,75 @@
+SphereClient = require '../lib/client'
+RepeaterTaskQueue = require '../lib/repeater-task-queue'
+Config = require('../config').config
+util = require('util')
+describe 'RepeaterTaskQueue', ->
+
+  repeaterOptions = {
+    attempts: 5,
+    timeout: 200
+  }
+
+  beforeEach ->
+    task = new RepeaterTaskQueue { maxParallel: 30 }, { attempts: 5, timeout: 200, timeoutType: 'v' }
+    sphereConfig = { config: Config, task }
+    @client = new SphereClient sphereConfig
+
+
+  it 'should finally resolve after three tries', (done) ->
+
+    callsMap = {
+      0: { statusCode: 500, message: 'ETIMEDOUT' }
+      1: { statusCode: 500, message: 'ETIMEDOUT' }
+      2: { statusCode: 200, message: 'success' }
+    }
+    callCount = 0
+    spyOn(@client._rest, 'GET').andCallFake (resource, callback) ->
+      currentCall = callsMap[callCount]
+      callCount++
+      statusCode = currentCall.statusCode
+      message = currentCall.message
+      callback(null, { statusCode }, { message })
+
+    @client.products.fetch()
+    .then (res) =>
+      expect(@client._rest.GET.calls.length).toEqual 3
+      expect(res.body.message).toEqual 'success'
+      done()
+    .catch (err) -> done(err)
+
+
+  it 'should repeat requests several times for 5xx error codes', (done) ->
+    spyOn(@client._rest, 'GET').andCallFake (resource, callback) ->
+      callback(null, { statusCode: 500 }, { code: 500 })
+
+    @client.products.fetch()
+      .then ->
+        done 'Error expected'
+      .catch =>
+        expect(@client._rest.GET.calls.length).toEqual repeaterOptions.attempts
+        done()
+
+
+  it 'should repeat requests several times for certain error messages', (done) ->
+    spyOn(@client._rest, 'GET').andCallFake (resource, callback) ->
+      callback(null, { statusCode: 500 }, { message: 'ETIMEDOUT' })
+
+    @client.products.fetch()
+      .then ->
+        done 'Error expected'
+      .catch =>
+        expect(@client._rest.GET.calls.length).toEqual repeaterOptions.attempts
+        done()
+
+
+  it 'should not repeat requests for non-5xx errors', (done) ->
+    spyOn(@client._rest, 'GET').andCallFake (resource, callback) ->
+      callback(null, { statusCode: 400 }, { message: 'something' })
+
+    @client.products.fetch()
+    .then ->
+      done 'Error expected'
+    .catch (err) =>
+      expect(err.message).toEqual 'something'
+      expect(@client._rest.GET.calls.length).toEqual 1
+      done()

--- a/src/spec/repeater-task-queue.spec.coffee
+++ b/src/spec/repeater-task-queue.spec.coffee
@@ -20,8 +20,9 @@ describe 'RepeaterTaskQueue', ->
 
     callsMap = {
       0: { statusCode: 500, message: 'ETIMEDOUT' }
-      1: { statusCode: 500, message: 'ETIMEDOUT' }
-      2: { statusCode: 200, message: 'success' }
+      1: { code: 500, message: 'ETIMEDOUT' }
+      2: { code: 789, message: 'ETIMEDOUT' }
+      3: { statusCode: 200, message: 'success' }
     }
     callCount = 0
     spyOn(@client._rest, 'GET').andCallFake (resource, callback) ->
@@ -33,7 +34,7 @@ describe 'RepeaterTaskQueue', ->
 
     @client.products.fetch()
     .then (res) =>
-      expect(@client._rest.GET.calls.length).toEqual 3
+      expect(@client._rest.GET.calls.length).toEqual 4
       expect(res.body.message).toEqual 'success'
       done()
     .catch (err) -> done(err)

--- a/src/spec/repeater-task-queue.spec.coffee
+++ b/src/spec/repeater-task-queue.spec.coffee
@@ -16,7 +16,7 @@ describe 'RepeaterTaskQueue', ->
     @client = new SphereClient sphereConfig
 
 
-  it 'should finally resolve after three tries', (done) ->
+  it 'should finally resolve after four tries', (done) ->
 
     callsMap = {
       0: { statusCode: 500, message: 'ETIMEDOUT' }

--- a/src/spec/repeater-task-queue.spec.coffee
+++ b/src/spec/repeater-task-queue.spec.coffee
@@ -2,6 +2,7 @@ SphereClient = require '../lib/client'
 RepeaterTaskQueue = require '../lib/repeater-task-queue'
 Config = require('../config').config
 util = require('util')
+_ = require 'underscore'
 describe 'RepeaterTaskQueue', ->
 
   repeaterOptions = {
@@ -73,3 +74,40 @@ describe 'RepeaterTaskQueue', ->
       expect(err.message).toEqual 'something'
       expect(@client._rest.GET.calls.length).toEqual 1
       done()
+
+  it 'should set default repeater options on empty object', (done) ->
+    retryKeywords = [
+      'ETIMEDOUT'
+      'socket hang up'
+      'write EPROTO'
+      'Retry later'
+      'I am the LoadBalancer of'
+      'Gateway Timeout'
+      'Bad Gateway'
+      'EAI_AGAIN'
+      'ESOCKETTIMEDOUT'
+      'Oops. This shouldn\'t happen'
+      'InternalServerError: Undefined'
+      'Temporary overloading'
+      'read ECONNRESET'
+      'getaddrinfo ENOTFOUND'
+      'Cannot commit on stream id'
+    ]
+    task = new RepeaterTaskQueue {}, {}
+    expect(_.isEqual(task.repeaterOptions.retryKeywords, retryKeywords)).toEqual true
+    expect(task.repeaterOptions.attempts).toEqual 50
+    expect(task.repeaterOptions.timeout).toEqual 200
+    expect(task.repeaterOptions.timeoutType).toEqual 'v'
+    done()
+
+  it 'should set custom repeater options', (done) ->
+    retryKeywords = [
+      'test1'
+      'test2'
+    ]
+    task = new RepeaterTaskQueue {}, { attempts: 7, timeout: 211, timeoutType: 'c',  retryKeywords: retryKeywords}
+    expect(_.isEqual(task.repeaterOptions.retryKeywords, retryKeywords)).toEqual true
+    expect(task.repeaterOptions.attempts).toEqual 7
+    expect(task.repeaterOptions.timeout).toEqual 211
+    expect(task.repeaterOptions.timeoutType).toEqual 'c'
+    done()

--- a/src/spec/sync/inventory-sync.spec.coffee
+++ b/src/spec/sync/inventory-sync.spec.coffee
@@ -117,7 +117,10 @@ describe 'InventorySync', ->
             id: '123'
           },
           fields: {
-            nac: 'ho'
+            nac: 'ho',
+            pie: {
+              'nl': 'taart'
+            }
           }
         }
 
@@ -129,7 +132,7 @@ describe 'InventorySync', ->
         update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
         expect(update.actions[0].action).toBe 'setCustomType'
         expect(update.actions[0].type).toEqual { typeId: 'type', id: '123' }
-        expect(update.actions[0].fields).toEqual { nac: 'ho' }
+        expect(update.actions[0].fields).toEqual { nac: 'ho', pie: {nl:'taart'} }
 
       it 'should set completely new custom type and fields', ->
         ieOld =
@@ -138,7 +141,7 @@ describe 'InventorySync', ->
         update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
         expect(update.actions[0].action).toBe 'setCustomType'
         expect(update.actions[0].type).toEqual { typeId: 'type', id: '123' }
-        expect(update.actions[0].fields).toEqual { nac: 'ho' }
+        expect(update.actions[0].fields).toEqual { nac: 'ho', pie: {nl: 'taart'} }
 
       it 'should update custom type', ->
         ieOld =
@@ -171,3 +174,24 @@ describe 'InventorySync', ->
         expect(update.actions[0].action).toBe 'setCustomField'
         expect(update.actions[0].name).toBe 'nac'
         expect(update.actions[0].value).toBe 'ho'
+
+      it 'should update localized custom fields', ->
+        ieOld =
+          sku: 'abc'
+          custom: {
+            type: {
+              typeId: 'type',
+              id: '123'
+            },
+            fields: {
+              nac: 'ho',
+              pie: {
+                'nl': 'echt niet'
+              }
+            }
+          }
+
+        update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
+        expect(update.actions[0].action).toBe 'setCustomField'
+        expect(update.actions[0].name).toBe 'pie'
+        expect(update.actions[0].value).toEqual {'nl': 'taart'}

--- a/src/spec/sync/inventory-sync.spec.coffee
+++ b/src/spec/sync/inventory-sync.spec.coffee
@@ -128,7 +128,7 @@ describe 'InventorySync', ->
 
         update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
         expect(update.actions[0].action).toBe 'setCustomType'
-        expect(update.actions[0].type).toEqual { typeId : 'type', id : '123' }
+        expect(update.actions[0].type).toEqual { typeId: 'type', id: '123' }
         expect(update.actions[0].fields).toEqual { nac: 'ho' }
 
       it 'should update custom type', ->
@@ -143,7 +143,7 @@ describe 'InventorySync', ->
 
         update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
         expect(update.actions[0].action).toBe 'setCustomType'
-        expect(update.actions[0].type).toEqual { typeId : 'type', id : '123' }
+        expect(update.actions[0].type).toEqual { typeId: 'type', id: '123' }
 
       it 'should update custom fields', ->
         ieOld =

--- a/src/spec/sync/inventory-sync.spec.coffee
+++ b/src/spec/sync/inventory-sync.spec.coffee
@@ -107,3 +107,58 @@ describe 'InventorySync', ->
       expect(update).toBeDefined()
       expect(update.actions[0].action).toBe 'setExpectedDelivery'
       expect(update.actions[0].expectedDelivery).toBeUndefined()
+
+    describe 'actionsMapCustom', ->
+      ieNew =
+        sku: 'abc'
+        custom: {
+          type: {
+            typeId: 'type',
+            id: '123'
+          },
+          fields: {
+            nac: 'ho'
+          }
+        }
+
+      it 'should set new custom type and fields', ->
+        ieOld =
+          sku: 'abc'
+          custom: {}
+
+        update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
+        expect(update.actions[0].action).toBe 'setCustomType'
+        expect(update.actions[0].type).toEqual { typeId : 'type', id : '123' }
+        expect(update.actions[0].fields).toEqual { nac: 'ho' }
+
+      it 'should update custom type', ->
+        ieOld =
+          sku: 'abc'
+          custom: {
+            type: {
+              typeId: 'type',
+              id: '000'
+            }
+          }
+
+        update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
+        expect(update.actions[0].action).toBe 'setCustomType'
+        expect(update.actions[0].type).toEqual { typeId : 'type', id : '123' }
+
+      it 'should update custom fields', ->
+        ieOld =
+          sku: 'abc'
+          custom: {
+            type: {
+              typeId: 'type',
+              id: '123'
+            },
+            fields: {
+              nac: 'choo'
+            }
+          }
+
+        update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
+        expect(update.actions[0].action).toBe 'setCustomField'
+        expect(update.actions[0].name).toBe 'nac'
+        expect(update.actions[0].value).toBe 'ho'

--- a/src/spec/sync/inventory-sync.spec.coffee
+++ b/src/spec/sync/inventory-sync.spec.coffee
@@ -121,10 +121,19 @@ describe 'InventorySync', ->
           }
         }
 
-      it 'should set new custom type and fields', ->
+      it 'should set empty new custom type and fields', ->
         ieOld =
           sku: 'abc'
           custom: {}
+
+        update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
+        expect(update.actions[0].action).toBe 'setCustomType'
+        expect(update.actions[0].type).toEqual { typeId: 'type', id: '123' }
+        expect(update.actions[0].fields).toEqual { nac: 'ho' }
+
+      it 'should set completely new custom type and fields', ->
+        ieOld =
+          sku: 'abc'
 
         update = @sync.buildActions(ieNew, ieOld).getUpdatePayload()
         expect(update.actions[0].action).toBe 'setCustomType'

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -195,28 +195,17 @@ describe 'ProductSync', ->
       oldProduct =
         id: '123'
         version: 1
-        masterVariant:
-          id: 1
-          sku: 'v1'
-          attributes: [{name: 'foo', value: 'bar'}]
-        variants: [
-          { id: 2, sku: 'v2', attributes: [{name: 'foo', value: 'qux'}] }
-          { id: 3, sku: 'v3', attributes: [{name: 'foo', value: 'baz'}] }
-        ]
+        variants: []
 
       newProduct =
         id: '123'
         variants: [
-          { id: 2, sku: 'v2', attributes: [{name: 'foo', value: 'another value'}] }
-          { id: 3, sku: 'v4', attributes: [{name: 'foo', value: 'i dont care'}] }
-          { id: 4, sku: 'v3', attributes: [{name: 'foo', value: 'yet another'}] }
+          { id: 2, sku: 'v2', attributes: [{name: 'foo', value: 'new variant'}] }
         ]
       update = @sync.buildActions(newProduct, oldProduct).getUpdatePayload()
       expected_update =
         actions: [
-          { action: 'setAttribute', variantId: 2, name: 'foo', value: 'another value' }
-          { action: 'setAttribute', variantId: 3, name: 'foo', value: 'yet another' }
-          { action: 'addVariant', sku: 'v4', attributes: [{ name: 'foo', value: 'i dont care' }] }
+          { action: 'addVariant', sku: 'v2', attributes: [{ name: 'foo', value: 'new variant' }] }
         ]
         version: oldProduct.version
       expect(update).toEqual expected_update

--- a/src/spec/sync/product-sync.spec.coffee
+++ b/src/spec/sync/product-sync.spec.coffee
@@ -64,6 +64,15 @@ NEW_PRODUCT =
       {value: {currencyCode: 'EUR', centAmount: 100}},
       {value: {currencyCode: 'EUR', centAmount: 3800}}, # change
       {value: {currencyCode: 'EUR', centAmount: 1100}, country: 'IT'} # change
+      {
+        value: {currencyCode: 'JPY', centAmount: 9001},
+        custom: {
+          type: {
+            typeId: 'type', id: 'decaf-f005ba11-abaca',
+            fields: {superCustom: 'super true'}
+          }
+        }
+      }
     ]
   categoryOrderHints:
     myFancyCategoryId: 0.9
@@ -147,6 +156,7 @@ describe 'ProductSync', ->
           { action: 'removePrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 6559 }, country: 'FR' } }
           { action: 'removePrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 13118 }, country: 'BE' } }
           { action: 'addPrice', variantId: 1, price: {value: {currencyCode: 'EUR', centAmount: 1100}, country: 'IT'} }
+          { action: 'addPrice', variantId: 1, price: {value: {currencyCode: 'JPY', centAmount: 9001}, custom: {type: {typeId: 'type', id: 'decaf-f005ba11-abaca', fields: {superCustom: 'super true'}}}} }
           { action: 'addPrice', variantId: 2, price: {value: {currencyCode: 'EUR', centAmount: 2200}, customerGroup: {id: '59c64f80-6472-474e-b5be-dc57b45b2faf', typeId: 'customer-group'}} }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 4790 }, country: 'DE', customerGroup: { id: 'special-price-id', typeId: 'customer-group' } } }
           { action: 'addPrice', variantId: 77, price: { value: { currencyCode: 'EUR', centAmount: 5889 }, country: 'AT' } }


### PR DESCRIPTION
sphere-node-sdk currently has a 3 vulnerable dependency paths, introducing 3 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/sphereio/sphere-node-sdk) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade `debug` dependency as well.

Stay Secure,
The Snyk Team
